### PR TITLE
Choose syntax from file extension, not content.

### DIFF
--- a/lib/jekyll-sass-converter.rb
+++ b/lib/jekyll-sass-converter.rb
@@ -1,4 +1,5 @@
 require "jekyll-sass-converter/version"
+require "jekyll/converters/scss"
 require "jekyll/converters/sass"
 
 module JekyllSassConverter

--- a/lib/jekyll/converters/sass.rb
+++ b/lib/jekyll/converters/sass.rb
@@ -3,64 +3,16 @@ require 'jekyll/utils'
 
 module Jekyll
   module Converters
-    class Sass < Converter
+    class Sass < Scss
       safe true
       priority :low
 
       def matches(ext)
-        ext =~ /^\.s(a|c)ss$/i
+        ext =~ /^\.sass$/i
       end
 
-      def output_ext(ext)
-        ".css"
-      end
-
-      def jekyll_sass_configuration
-        options = @config["sass"] || {}
-        unless options["style"].nil?
-          options["style"] = options["style"].to_s.gsub(/\A:/, '').to_sym
-        end
-        options
-      end
-
-      def sass_build_configuration_options(overrides)
-        Jekyll::Utils.symbolize_hash_keys(
-          Jekyll::Utils.deep_merge_hashes(jekyll_sass_configuration, overrides)
-        )
-      end
-
-      def syntax_type_of_content(content)
-        if content.include?(";") || content.include?("{")
-          :scss
-        else
-          :sass
-        end
-      end
-
-      def sass_dir
-        return "_sass" if jekyll_sass_configuration["sass_dir"].to_s.empty?
-        jekyll_sass_configuration["sass_dir"]
-      end
-
-      def sass_dir_relative_to_site_source
-        # FIXME: Not Windows-safe. Can only change once Jekyll 2.0.0 is out
-        Jekyll.sanitized_path(@config["source"], sass_dir)
-      end
-
-      def allow_caching?
-        !@config["safe"]
-      end
-
-      def sass_configs(content = "")
-        sass_build_configuration_options({
-          "syntax" => syntax_type_of_content(content),
-          "cache"  => allow_caching?,
-          "load_paths" => [sass_dir_relative_to_site_source]
-        })
-      end
-
-      def convert(content)
-        ::Sass.compile(content, sass_configs(content))
+      def sass_syntax(content)
+        :sass
       end
     end
   end

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -1,0 +1,63 @@
+require 'sass'
+require 'jekyll/utils'
+
+module Jekyll
+  module Converters
+    class Scss < Converter
+      safe true
+      priority :low
+
+      def matches(ext)
+        ext =~ /^\.scss$/i
+      end
+
+      def output_ext(ext)
+        ".css"
+      end
+
+      def jekyll_sass_configuration
+        options = @config["sass"] || {}
+        unless options["style"].nil?
+          options["style"] = options["style"].to_s.gsub(/\A:/, '').to_sym
+        end
+        options
+      end
+
+      def sass_build_configuration_options(overrides)
+        Jekyll::Utils.symbolize_hash_keys(
+          Jekyll::Utils.deep_merge_hashes(jekyll_sass_configuration, overrides)
+        )
+      end
+
+      def sass_syntax
+        :scss
+      end
+
+      def sass_dir
+        return "_sass" if jekyll_sass_configuration["sass_dir"].to_s.empty?
+        jekyll_sass_configuration["sass_dir"]
+      end
+
+      def sass_dir_relative_to_site_source
+        # FIXME: Not Windows-safe. Can only change once Jekyll 2.0.0 is out
+        Jekyll.sanitized_path(@config["source"], sass_dir)
+      end
+
+      def allow_caching?
+        !@config["safe"]
+      end
+
+      def sass_configs(content = "")
+        sass_build_configuration_options({
+          "syntax" => sass_syntax,
+          "cache"  => allow_caching?,
+          "load_paths" => [sass_dir_relative_to_site_source]
+        })
+      end
+
+      def convert(content)
+        ::Sass.compile(content, sass_configs(content))
+      end
+    end
+  end
+end

--- a/spec/sass_coverter_spec.rb
+++ b/spec/sass_coverter_spec.rb
@@ -6,6 +6,7 @@ describe(Jekyll::Converters::Sass) do
   end
   let(:sass_content) do
     <<-SASS
+// tl;dr some sass
 $font-stack: Helvetica, sans-serif
 body
   font-family: $font-stack


### PR DESCRIPTION
Right now the Sass Converter decides syntax [based on content](https://github.com/jekyll/jekyll-sass-converter/blob/master/lib/jekyll/converters/sass.rb#L33) This is unreliable since comments can contain any characters, for example:

``` sass
// Some grid framework
// TL;DR it's a grid framework
// Ok, so here's the deal about this grid, blah blah...

*
  box-sizing: border-box;
```

This is valid Sass but will be parsed as Scss by Jekyll's sass-converter since it contains a `;` character.
### My Solution

I wish Converters gave you access to the path of the file being converted. If they did, we could simply match on the path and choose the right extension. Since it doesn't I have split the Converter into two; one which matches `scss` files and contains all the converter code, and one which extends the `scss` converter but matches on `sass` files.

**Unfortunately** I think the tests must be rewritten, one for each converter. This is something I don't know how to do, but I've introduced a failing test to get that started.
