### PR TITLE
Create a whitelist of sass opts in safe mode.

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -28,9 +28,20 @@ module Jekyll
       end
 
       def sass_build_configuration_options(overrides)
-        Jekyll::Utils.symbolize_hash_keys(
-          Jekyll::Utils.deep_merge_hashes(jekyll_sass_configuration, overrides)
-        )
+        if safe?
+          {
+            :load_paths => sass_load_paths,
+            :syntax     => syntax,
+            :cache      => false
+          }
+        else
+          Jekyll::Utils.symbolize_hash_keys(
+            Jekyll::Utils.deep_merge_hashes(
+              jekyll_sass_configuration,
+              overrides
+            )
+          )
+        end
       end
 
       def syntax


### PR DESCRIPTION
This PR essentially locks down the entire configuration process in safe mode such that, well, nothing custom can be set. If we want to allow users to set any of the configuration options, we can do that, too. But for now, it leaves everything to default except `cache`, `load_paths`, and `syntax`.

There is a huge list of [Sass configuration options](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#options).

/cc @mastahyeti @benbalter
