### PR TITLE
Support for Compass

### DIFF
--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "jekyll", "~> 2.0"
+  spec.add_development_dependency "compass", "~> 1.0"
 end

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -65,6 +65,13 @@ module Jekyll
         Array(jekyll_sass_configuration["load_paths"])
       end
 
+      def compass_sass_load_paths
+        require 'compass'
+        Compass.configuration.sass_load_paths
+      rescue LoadError
+        []
+      end
+
       def sass_dir_relative_to_site_source
         Jekyll.sanitized_path(@config["source"], sass_dir)
       end
@@ -73,8 +80,11 @@ module Jekyll
         if safe?
           [sass_dir_relative_to_site_source]
         else
-          (user_sass_load_paths + [sass_dir_relative_to_site_source]).uniq
-        end.select { |load_path| File.directory?(load_path) }
+          (user_sass_load_paths + [sass_dir_relative_to_site_source]).uniq +
+            compass_sass_load_paths
+        end.select { |load_path|
+          !load_path.is_a?(String) || File.directory?(load_path)
+        }
       end
 
       def allow_caching?


### PR DESCRIPTION
To use compass library, we have to hard code compass library path (e.g. `/path/to/gem/ruby/2.1.0/gems/compass-core-1.0.1/stylesheets`)
 to `sass.load_paths`. It's so painful.

So, I add a new configuration option `sass.compass` (default: `false`).

If this option is enabled in unsafe mode, compass libraries are automatically imported.
