### PR TITLE
Find Jekyll::Converters::Scss

### DIFF
--- a/lib/jekyll/converters/sass.rb
+++ b/lib/jekyll/converters/sass.rb
@@ -1,5 +1,6 @@
 require 'sass'
 require 'jekyll/utils'
+require 'jekyll/converters/scss'
 
 module Jekyll
   module Converters


### PR DESCRIPTION
Fix

```
/usr/lib/ruby/vendor_ruby/jekyll/converters/sass.rb:7:in `<module:Converters>': uninitialized constant Jekyll::Converters::Scss (NameError)
    from /usr/lib/ruby/vendor_ruby/jekyll/converters/sass.rb:6:in `<module:Jekyll>'
    from /usr/lib/ruby/vendor_ruby/jekyll/converters/sass.rb:5:in `<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/lib/ruby/vendor_ruby/jekyll.rb:11:in `block in require_all'
    from /usr/lib/ruby/vendor_ruby/jekyll.rb:10:in `each'
    from /usr/lib/ruby/vendor_ruby/jekyll.rb:10:in `require_all'
    from /usr/lib/ruby/vendor_ruby/jekyll.rb:64:in `<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/bin/jekyll:6:in `<main>'
```

when running `jekyll` on Ubuntu 14.10.
