### PR TITLE
Strip byte order mark from generated compressed Sass/SCSS

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8:
+
 require 'sass'
 require 'jekyll/utils'
 

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -4,6 +4,7 @@ require 'jekyll/utils'
 module Jekyll
   module Converters
     class Scss < Converter
+      BYTE_ORDER_MARK = /^\xEF\xBB\xBF/
       SyntaxError = Class.new(ArgumentError)
 
       safe true
@@ -83,6 +84,14 @@ module Jekyll
         !safe?
       end
 
+      def add_charset?
+        if jekyll_sass_configuration["add_charset"].nil?
+          true
+        else
+          jekyll_sass_configuration["add_charset"]
+        end
+      end
+
       def sass_configs
         sass_build_configuration_options({
           "syntax"     => syntax,
@@ -92,7 +101,9 @@ module Jekyll
       end
 
       def convert(content)
-        ::Sass.compile(content, sass_configs)
+        output = ::Sass.compile(content, sass_configs)
+        replacement = add_charset? ? '@charset "UTF-8";' : ''
+        output.sub(BYTE_ORDER_MARK, replacement)
       rescue ::Sass::SyntaxError => e
         raise SyntaxError.new("#{e.to_s} on line #{e.sass_line}")
       end

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -55,14 +55,14 @@ SASS
     end
 
     it "removes byte order mark from compressed Sass" do
-      result = converter({ "style" => :compressed }).convert("a\n  content: \"\"")
-      expect(result).to eql("@charset \"UTF-8\";a{content:\"\"}\n")
+      result = converter({ "style" => :compressed }).convert("a\n  content: \"\uF015\"")
+      expect(result).to eql("@charset \"UTF-8\";a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
 
     it "does not include the charset if asked not to" do
-      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a\n  content: \"\"")
-      expect(result).to eql("a{content:\"\"}\n")
+      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a\n  content: \"\uF015\"")
+      expect(result).to eql("a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
   end

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -53,6 +53,17 @@ SASS
         converter.convert(invalid_content)
       }.to raise_error(Jekyll::Converters::Scss::SyntaxError, error_message)
     end
-  end
 
+    it "removes byte order mark from compressed Sass" do
+      result = converter({ "style" => :compressed }).convert("a\n  content: \"\"")
+      expect(result).to eql("@charset \"UTF-8\";a{content:\"\"}\n")
+      expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
+    end
+
+    it "does not include the charset if asked not to" do
+      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a\n  content: \"\"")
+      expect(result).to eql("a{content:\"\"}\n")
+      expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
+    end
+  end
 end

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -122,6 +122,18 @@ SCSS
         converter.convert(invalid_content)
       }.to raise_error(Jekyll::Converters::Scss::SyntaxError, error_message)
     end
+
+    it "removes byte order mark from compressed SCSS" do
+      result = converter({ "style" => :compressed }).convert("a{content:\"\"}")
+      expect(result).to eql("@charset \"UTF-8\";a{content:\"\"}\n")
+      expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
+    end
+
+    it "does not include the charset if asked not to" do
+      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a{content:\"\"}")
+      expect(result).to eql("a{content:\"\"}\n")
+      expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
+    end
   end
 
   context "importing partials" do

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -124,14 +124,14 @@ SCSS
     end
 
     it "removes byte order mark from compressed SCSS" do
-      result = converter({ "style" => :compressed }).convert("a{content:\"\"}")
-      expect(result).to eql("@charset \"UTF-8\";a{content:\"\"}\n")
+      result = converter({ "style" => :compressed }).convert("a{content:\"\uF015\"}")
+      expect(result).to eql("@charset \"UTF-8\";a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
 
     it "does not include the charset if asked not to" do
-      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a{content:\"\"}")
-      expect(result).to eql("a{content:\"\"}\n")
+      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a{content:\"\uF015\"}")
+      expect(result).to eql("a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
   end


### PR DESCRIPTION
Sass optimizes compressed CSS output by adding a Byte Order Mark when the CSS contains non-ASCII characters. In Jekyll's use case, this can result in a BOM ending up in the middle of a generated HTML file when the `scssify`/`sassify` filters are used. The result is unparseable CSS.

The solution is to remove the Byte Order Mark and replace it with the equivalent `@charset "UTF-8";` rule.

In some cases, such as in highlighted snippets, it may be undesirable for the charset rule to be injected. Thus, a default-to-true configuration option `add_charset` is included allowing Jekyll users to disable this if desired.

This is a migration of Jekyll [#3914](https://github.com/jekyll/jekyll/issues/3914) and its associated [PR #3934](https://github.com/jekyll/jekyll/pull/3934), CC: @envygeeks, @parkr.