### PR TITLE
Update the version of Sass to be 3.4.x

### DIFF
--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r{^lib/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sass", "~> 3.2"
+  spec.add_runtime_dependency "sass", "~> 3.4"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This will update the version of Sass to be the most recent (per the conversation at https://github.com/jekyll/jekyll/issues/3973). It should at least allow for #12 to be possible (source maps enabled in 3.3).

As a note: I did some local tests to ensure generation could occur— but am not sure the best way to run tests outside of that. Also will need to bump the version number for deploy. 