### PR TITLE
add_charset false by default, but still strip BOM

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8:
+# encoding: utf-8
 
 require 'sass'
 require 'jekyll/utils'
@@ -87,11 +87,7 @@ module Jekyll
       end
 
       def add_charset?
-        if jekyll_sass_configuration["add_charset"].nil?
-          true
-        else
-          jekyll_sass_configuration["add_charset"]
-        end
+        !!jekyll_sass_configuration["add_charset"]
       end
 
       def sass_configs

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -56,13 +56,13 @@ SASS
 
     it "removes byte order mark from compressed Sass" do
       result = converter({ "style" => :compressed }).convert("a\n  content: \"\uF015\"")
-      expect(result).to eql("@charset \"UTF-8\";a{content:\"\uF015\"}\n")
+      expect(result).to eql("a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
 
     it "does not include the charset if asked not to" do
-      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a\n  content: \"\uF015\"")
-      expect(result).to eql("a{content:\"\uF015\"}\n")
+      result = converter({ "style" => :compressed, "add_charset" => true }).convert("a\n  content: \"\uF015\"")
+      expect(result).to eql("@charset \"UTF-8\";a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
   end

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -125,13 +125,13 @@ SCSS
 
     it "removes byte order mark from compressed SCSS" do
       result = converter({ "style" => :compressed }).convert("a{content:\"\uF015\"}")
-      expect(result).to eql("@charset \"UTF-8\";a{content:\"\uF015\"}\n")
+      expect(result).to eql("a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
 
-    it "does not include the charset if asked not to" do
-      result = converter({ "style" => :compressed, "add_charset" => false }).convert("a{content:\"\uF015\"}")
-      expect(result).to eql("a{content:\"\uF015\"}\n")
+    it "does not include the charset unless asked to" do
+      result = converter({ "style" => :compressed, "add_charset" => true }).convert("a{content:\"\uF015\"}")
+      expect(result).to eql("@charset \"UTF-8\";a{content:\"\uF015\"}\n")
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
   end


### PR DESCRIPTION
Ref #39

`add_charset` is now set to `false` by default.