### PR TITLE
Allow multiple SASS load paths, even in safe mode

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -70,15 +70,17 @@ module Jekyll
         Array(jekyll_sass_configuration["load_paths"])
       end
 
-      def sass_dir_relative_to_site_source
-        Jekyll.sanitized_path(@config["source"], sass_dir)
+      def sass_load_paths_relative_to_site_source
+        Array(sass_dir).map do |dir|
+          Jekyll.sanitized_path(@config["source"], dir)
+        end
       end
 
       def sass_load_paths
         if safe?
-          [sass_dir_relative_to_site_source]
+          sass_load_paths_relative_to_site_source
         else
-          (user_sass_load_paths + [sass_dir_relative_to_site_source]).uniq
+          (user_sass_load_paths + sass_load_paths_relative_to_site_source).uniq
         end.select { |load_path| File.directory?(load_path) }
       end
 
@@ -99,6 +101,7 @@ module Jekyll
       end
 
       def convert(content)
+        puts sass_configs
         output = ::Sass.compile(content, sass_configs)
         replacement = add_charset? ? '@charset "UTF-8";' : ''
         output.sub(BYTE_ORDER_MARK, replacement)

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -74,8 +74,8 @@ SCSS
 
         it "not allow sass_dirs outside of site source" do
           expect(
-            converter({"sass_dir" => "/etc/passwd"}).sass_dir_relative_to_site_source
-          ).to eql(source_dir("etc/passwd"))
+            converter({"sass_dir" => "/etc/passwd"}).sass_load_paths_relative_to_site_source
+          ).to eql([source_dir("etc/passwd")])
         end
       end
     end


### PR DESCRIPTION
Allows `sass_dir` to be an array, see #4610