### PR TITLE
Allow load_paths in safe mode with sanitization

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -72,11 +72,16 @@ module Jekyll
       end
 
       def sass_load_paths
+        paths = (user_sass_load_paths + [sass_dir_relative_to_site_source])
+
         if safe?
-          [sass_dir_relative_to_site_source]
-        else
-          (user_sass_load_paths + [sass_dir_relative_to_site_source]).uniq
-        end.select { |load_path| File.directory?(load_path) }
+          paths.map! { |path| Jekyll.sanitized_path(@config["source"], path) }
+        end
+
+        # Expand file globs (e.g. `node_modules/*/node_modules` )
+        paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+
+        paths.select { |path| File.directory?(path) }
       end
 
       def allow_caching?

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -80,8 +80,8 @@ module Jekyll
 
         # Expand file globs (e.g. `node_modules/*/node_modules` )
         Dir.chdir(@config["source"]) do
-          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
-          paths.map! { |path| File.expand_path(path) }
+          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq.
+                        map { |path| File.expand_path(path) }
         end
 
         paths.select { |path| File.directory?(path) }

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -79,7 +79,10 @@ module Jekyll
         end
 
         # Expand file globs (e.g. `node_modules/*/node_modules` )
-        paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+        Dir.chdir(@config["source"]) do
+          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+          paths.map! { |path| File.expand_path(path) }
+        end
 
         paths.select { |path| File.directory?(path) }
       end

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -75,16 +75,25 @@ module Jekyll
       end
 
       def sass_load_paths
-        paths = (user_sass_load_paths + [sass_dir_relative_to_site_source])
+        paths = user_sass_load_paths + [sass_dir_relative_to_site_source]
 
         if safe?
+          # Sanitize paths to prevent any attack vectors (.e.g. `/**/*`)
           paths.map! { |path| Jekyll.sanitized_path(@config["source"], path) }
         end
 
         # Expand file globs (e.g. `node_modules/*/node_modules` )
         Dir.chdir(@config["source"]) do
-          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq.
-                        map { |path| File.expand_path(path) }
+          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+
+          paths.map! do |path|
+            if safe?
+              # Sanitize again in case globbing was able to do something crazy.
+              Jekyll.sanitized_path(@config["source"], path)
+            else
+              File.expand_path(path)
+            end
+          end
         end
 
         paths.select { |path| File.directory?(path) }

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -83,7 +83,7 @@ SCSS
     context "in safe mode" do
       let(:verter) {
         Jekyll::Converters::Scss.new(site.config.merge({
-          "sass" => {},
+          "sass" => {"load_paths" => ["bower_components/*", Dir.tmpdir]},
           "safe" => true
         }))
       }
@@ -92,8 +92,11 @@ SCSS
         expect(verter.sass_configs[:cache]).to be_falsey
       end
 
-      it "forces load_paths to be just the local load path" do
-        expect(verter.sass_configs[:load_paths]).to eql([source_dir("_sass")])
+      it "sanitizes and globs load_paths" do
+        expect(verter.sass_configs[:load_paths]).to eql([
+          source_dir("bower_components/jquery"),
+          source_dir("_sass")
+        ])
       end
 
       it "allows the user to specify the style" do

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -251,7 +251,8 @@ SCSS
           "sass"   => {
             "load_paths" => [
               "bower_components/*",
-              Dir.tmpdir
+              Dir.tmpdir,
+              "../.."
             ]
           }
         }))
@@ -263,6 +264,13 @@ SCSS
 
       it "ignores external load paths" do
         expect(converter.sass_load_paths).not_to include(Dir.tmpdir)
+      end
+
+      it "does not allow traversing outside source directory" do
+        converter.sass_load_paths.each do |path|
+          expect(path).to include(source_dir)
+          expect(path).not_to include('..')
+        end
       end
     end
   end

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -173,7 +173,7 @@ SCSS
         FileUtils.mkdir_p(external_library) unless File.directory?(external_library)
       end
       after(:each) do
-        FileUtils.mkdir_p(external_library) unless File.directory?(external_library)
+        FileUtils.rmdir(external_library) if File.directory?(external_library)
       end
 
       it "recognizes the new load path" do
@@ -239,7 +239,7 @@ SCSS
     end
 
     after(:each) do
-      FileUtils.mkdir_p(internal_library) unless File.directory?(internal_library)
+      FileUtils.rmdir(internal_library) if File.directory?(internal_library)
     end
 
     context "unsafe mode" do

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -232,7 +232,7 @@ SCSS
 
   context "importing from internal libraries" do
     let(:internal_library) { source_dir("bower_components/jquery") }
-    let(:converter) { site.getConverterImpl(Jekyll::Converters::Scss) }
+    let(:converter) { scss_converter_instance(site) }
 
     before(:each) do
       FileUtils.mkdir_p(internal_library) unless File.directory?(internal_library)


### PR DESCRIPTION
`load_paths` is currently only supported in safe mode. This enables it all the time, but sanitizes the paths with `Jekyll.sanitized_path` in safe mode to ensure all paths are relative to the source directory. This also adds support for globbing (e.g. `**/*/node_modules` to add node modules and all transient dependencies to the load path).

Having multiple paths in the sass load path is really helpful when using package managers like bower or NPM. For example:

``` yaml
sass:
  load_paths:
  - bower_components
  - **/*/node_modules
```

The motivation for this change is so I can use the latest version of [primer](https://github.com/primer/primer) on a jekyll site.

/cc @jonrohan
