### PR TITLE
Upgrade to Jekyll 3 only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,9 @@ rvm:
 - 2.2.4
 - 2.1.8
 - ruby-head
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-  include:
-    - rvm: 1.9.3
-      env: JEKYLL_VERSION=2.5
-env:
-  matrix:
-    - JEKYLL_VERSION=2.5
-    - JEKYLL_VERSION=3.1
 branches:
   only:
     - master
-install:
-- travis_retry script/bootstrap
 script: script/cibuild
 notifications:
   irc:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 2.0"
+gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 3.0"

--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "jekyll", ">= 2.0"
+  spec.add_development_dependency "jekyll", ">= 3.0"
 end

--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sass", "~> 3.4"
+  spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "jekyll", ">= 3.0"
 end

--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sass", "~> 3.4"
-  spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.0"
 end


### PR DESCRIPTION
- [x] Remove testing infra for Jekyll 2.
- [ ] Fail at runtime (RubyGems forbids circular dependencies) if this gem is loaded by Jekyll 2.