### PR TITLE
Don't test Jekyll 2.5 against Ruby 2.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.3.0
 - 2.2.4
 - 2.1.8
 - ruby-head
@@ -11,6 +10,8 @@ matrix:
   include:
     - rvm: 1.9.3
       env: JEKYLL_VERSION=2.5
+    - rvm: 2.3.0
+      env: JEKYLL_VERSION=3.1
 env:
   matrix:
     - JEKYLL_VERSION=2.5


### PR DESCRIPTION
Jekyll 2.5 triggers a problem with Ruby 2.3's handling of singleton classes.