### PR TITLE
Allow importing plain .css files

### DIFF
--- a/lib/jekyll-sass-converter.rb
+++ b/lib/jekyll-sass-converter.rb
@@ -1,6 +1,7 @@
 require "jekyll-sass-converter/version"
 require "jekyll/converters/scss"
 require "jekyll/converters/sass"
+require "jekyll/sass/importer"
 
 module JekyllSassConverter
 end

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -72,11 +72,16 @@ module Jekyll
       end
 
       def sass_load_paths
+        paths = (user_sass_load_paths + [sass_dir_relative_to_site_source])
+
         if safe?
-          [sass_dir_relative_to_site_source]
-        else
-          (user_sass_load_paths + [sass_dir_relative_to_site_source]).uniq
-        end.select { |load_path| File.directory?(load_path) }
+          paths.map! { |path| Jekyll.sanitized_path(@config["source"], path) }
+        end
+
+        # Expand file globs (e.g. `node_modules/*/node_modules` )
+        paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+
+        paths.select { |path| File.directory?(path) }
       end
 
       def allow_caching?

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -37,10 +37,11 @@ module Jekyll
       def sass_build_configuration_options(overrides)
         if safe?
           {
-            :load_paths => sass_load_paths,
-            :syntax     => syntax,
-            :style      => sass_style,
-            :cache      => false
+            :load_paths          => sass_load_paths,
+            :syntax              => syntax,
+            :style               => sass_style,
+            :cache               => false,
+            :filesystem_importer => Jekyll::Sass::Importer
           }
         else
           Jekyll::Utils.symbolize_hash_keys(
@@ -100,9 +101,10 @@ module Jekyll
 
       def sass_configs
         sass_build_configuration_options({
-          "syntax"     => syntax,
-          "cache"      => allow_caching?,
-          "load_paths" => sass_load_paths
+          "syntax"              => syntax,
+          "cache"               => allow_caching?,
+          "load_paths"          => sass_load_paths,
+          "filesystem_importer" => Jekyll::Sass::Importer
         })
       end
 

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -80,8 +80,8 @@ module Jekyll
 
         # Expand file globs (e.g. `node_modules/*/node_modules` )
         Dir.chdir(@config["source"]) do
-          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
-          paths.map! { |path| File.expand_path(path) }
+          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq.
+                        map { |path| File.expand_path(path) }
         end
 
         paths.select { |path| File.directory?(path) }

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -79,7 +79,10 @@ module Jekyll
         end
 
         # Expand file globs (e.g. `node_modules/*/node_modules` )
-        paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+        Dir.chdir(@config["source"]) do
+          paths = paths.map { |path| Dir.glob(path) }.flatten.uniq
+          paths.map! { |path| File.expand_path(path) }
+        end
 
         paths.select { |path| File.directory?(path) }
       end

--- a/lib/jekyll/sass/importer.rb
+++ b/lib/jekyll/sass/importer.rb
@@ -1,0 +1,12 @@
+# Override default importer to allow importing .css files.
+#
+# See https://github.com/sass/sass/issues/556
+module Jekyll
+  module Sass
+    class Importer < ::Sass::Importers::Filesystem
+      def extensions
+        { 'css' => :scss }.merge(super)
+      end
+    end
+  end
+end

--- a/spec/dest/bower_components/oldschool/oldschool.css
+++ b/spec/dest/bower_components/oldschool/oldschool.css
@@ -1,0 +1,3 @@
+body {
+  background: pink;
+}

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -83,7 +83,7 @@ SCSS
     context "in safe mode" do
       let(:verter) {
         Jekyll::Converters::Scss.new(site.config.merge({
-          "sass" => {},
+          "sass" => {"load_paths" => ["bower_components/*", Dir.tmpdir]},
           "safe" => true
         }))
       }
@@ -92,8 +92,11 @@ SCSS
         expect(verter.sass_configs[:cache]).to be_falsey
       end
 
-      it "forces load_paths to be just the local load path" do
-        expect(verter.sass_configs[:load_paths]).to eql([source_dir("_sass")])
+      it "sanitizes and globs load_paths" do
+        expect(verter.sass_configs[:load_paths]).to eql([
+          source_dir("bower_components/jquery"),
+          source_dir("_sass")
+        ])
       end
 
       it "allows the user to specify the style" do

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -251,7 +251,8 @@ SCSS
           "sass"   => {
             "load_paths" => [
               "bower_components/*",
-              Dir.tmpdir
+              Dir.tmpdir,
+              "../.."
             ]
           }
         }))
@@ -263,6 +264,13 @@ SCSS
 
       it "ignores external load paths" do
         expect(converter.sass_load_paths).not_to include(Dir.tmpdir)
+      end
+
+      it "does not allow traversing outside source directory" do
+        converter.sass_load_paths.each do |path|
+          expect(path).to include(source_dir)
+          expect(path).not_to include('..')
+        end
       end
     end
   end

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -106,7 +106,7 @@ SCSS
       end
 
       it "only contains :syntax, :cache, :style, and :load_paths keys" do
-        expect(verter.sass_configs.keys).to eql([:load_paths, :syntax, :style, :cache])
+        expect(verter.sass_configs.keys).to eql([:load_paths, :syntax, :style, :cache, :filesystem_importer])
       end
     end
   end
@@ -165,7 +165,9 @@ SCSS
         Jekyll::Site.new(site_configuration.merge({
           "source" => sass_lib,
           "sass"   => {
-            "load_paths" => external_library
+            "load_paths" => [
+              source_dir("bower_components/*")
+            ]
           }
         }))
       end
@@ -286,4 +288,42 @@ SCSS
       end
     end
   end
+
+  context "importing plain CSS" do
+    let(:converter) { site.getConverterImpl(Jekyll::Converters::Scss) }
+
+    context "unsafe mode" do
+      let(:site) do
+        Jekyll::Site.new(site_configuration.merge({
+          "sass"   => {
+            "load_paths" => ["bower_components"]
+          }
+        }))
+      end
+
+      it "imports css files" do
+        expect(converter.convert('@import "oldschool/oldschool";')).to match(
+          "body {\n  background: pink; }\n"
+        )
+      end
+    end
+
+    context "safe mode" do
+      let(:site) do
+        Jekyll::Site.new(site_configuration.merge({
+          "safe"   => true,
+          "sass"   => {
+            "load_paths" => ["bower_components"]
+          }
+        }))
+      end
+
+      it "imports css files" do
+        expect(converter.convert('@import "oldschool/oldschool";')).to match(
+          "body { background: pink; }\n"
+        )
+      end
+    end
+  end
+
 end

--- a/spec/source/bower_components/oldschool/oldschool.css
+++ b/spec/source/bower_components/oldschool/oldschool.css
@@ -1,0 +1,3 @@
+body {
+  background: pink;
+}


### PR DESCRIPTION
It is common for external libraries and packages (e.g. from bower or npm) to have plain CSS. This makes it so they can be imported and minified in one CSS bundle without having to be renamed to `.scss`.

For example, if you install `normalize.css`…

```
$ npm install --save normalize.css`
```

…and then try to…

``` scss
@import "normalize.css/normalize";
```

Results in:

```
  Conversion error: Jekyll::Converters::Scss encountered an error while converting '/stylesheets/main.scss':
                    File to import not found or unreadable: normalize.css/normalize. Load paths: […] on line 2
```

There is a long discussion in https://github.com/sass/sass/issues/556 about whether Sass should do this by default or not. It's configured to work like this in Rails.

_Note:_ This PR depends on #50. See fcca647 for the meat of the changes for this PR.
