### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jekyll-sass-converter.gemspec
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Style/IndentHeredoc:
+  Exclude:
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 2.0"

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"

--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -1,24 +1,26 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-sass-converter/version'
+require "jekyll-sass-converter/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-sass-converter"
   spec.version       = JekyllSassConverter::VERSION
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
-  spec.summary       = %q{A basic Sass converter for Jekyll.}
+  spec.summary       = "A basic Sass converter for Jekyll."
   spec.homepage      = "https://github.com/jekyll/jekyll-sass-converter"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").grep(%r{^lib/})
+  spec.files         = `git ls-files -z`.split("\x0").grep(%r!^lib/!)
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sass", "~> 3.4"
 
   spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "jekyll", ">= 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "jekyll", ">= 2.0"
+  spec.add_development_dependency "rubocop", "~> 0.5"
 end

--- a/lib/jekyll-sass-converter.rb
+++ b/lib/jekyll-sass-converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll-sass-converter/version"
 require "jekyll/converters/scss"
 require "jekyll/converters/sass"

--- a/lib/jekyll-sass-converter/version.rb
+++ b/lib/jekyll-sass-converter/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllSassConverter
-  VERSION = "1.5.0"
+  VERSION = "1.5.0".freeze
 end

--- a/lib/jekyll/converters/sass.rb
+++ b/lib/jekyll/converters/sass.rb
@@ -1,6 +1,8 @@
-require 'sass'
-require 'jekyll/utils'
-require 'jekyll/converters/scss'
+# frozen_string_literal: true
+
+require "sass"
+require "jekyll/utils"
+require "jekyll/converters/scss"
 
 module Jekyll
   module Converters
@@ -9,7 +11,7 @@ module Jekyll
       priority :low
 
       def matches(ext)
-        ext =~ /^\.sass$/i
+        ext =~ %r!^\.sass$!i
       end
 
       def syntax

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -1,12 +1,12 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-require 'sass'
-require 'jekyll/utils'
+require "sass"
+require "jekyll/utils"
 
 module Jekyll
   module Converters
     class Scss < Converter
-      BYTE_ORDER_MARK = /^\xEF\xBB\xBF/
+      BYTE_ORDER_MARK = %r!^\xEF\xBB\xBF!
       SyntaxError = Class.new(ArgumentError)
 
       safe true
@@ -15,10 +15,10 @@ module Jekyll
       ALLOWED_STYLES = %w(nested expanded compact compressed).freeze
 
       def matches(ext)
-        ext =~ /^\.scss$/i
+        ext =~ %r!^\.scss$!i
       end
 
-      def output_ext(ext)
+      def output_ext(_ext)
         ".css"
       end
 
@@ -29,7 +29,7 @@ module Jekyll
       def jekyll_sass_configuration
         options = @config["sass"] || {}
         unless options["style"].nil?
-          options["style"] = options["style"].to_s.gsub(/\A:/, '').to_sym
+          options["style"] = options["style"].to_s.gsub(%r!\A:!, "").to_sym
         end
         options
       end
@@ -40,7 +40,7 @@ module Jekyll
             :load_paths => sass_load_paths,
             :syntax     => syntax,
             :style      => sass_style,
-            :cache      => false
+            :cache      => false,
           }
         else
           Jekyll::Utils.symbolize_hash_keys(
@@ -111,16 +111,16 @@ module Jekyll
         sass_build_configuration_options({
           "syntax"     => syntax,
           "cache"      => allow_caching?,
-          "load_paths" => sass_load_paths
+          "load_paths" => sass_load_paths,
         })
       end
 
       def convert(content)
         output = ::Sass.compile(content, sass_configs)
-        replacement = add_charset? ? '@charset "UTF-8";' : ''
+        replacement = add_charset? ? '@charset "UTF-8";' : ""
         output.sub(BYTE_ORDER_MARK, replacement)
       rescue ::Sass::SyntaxError => e
-        raise SyntaxError.new("#{e.to_s} on line #{e.sass_line}")
+        raise SyntaxError, "#{e} on line #{e.sass_line}"
       end
 
       private

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -1,4 +1,6 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe(Jekyll::Converters::Sass) do
   let(:site) do
@@ -25,11 +27,11 @@ SASS
   end
 
   def compressed(content)
-    content.gsub(/\s+/, '').gsub(/;}/, '}') + "\n"
+    content.gsub(%r!\s+!, "").gsub(%r!;}!, "}") + "\n"
   end
 
   def converter(overrides = {})
-    Jekyll::Converters::Sass.new(site_configuration({"sass" => overrides}))
+    Jekyll::Converters::Sass.new(site_configuration({ "sass" => overrides }))
   end
 
   context "matching file extensions" do
@@ -49,9 +51,9 @@ SASS
 
     it "includes the syntax error line in the syntax error message" do
       error_message = "Invalid CSS after \"$font-stack\": expected expression (e.g. 1px, bold), was \";\" on line 1"
-      expect {
+      expect do
         converter.convert(invalid_content)
-      }.to raise_error(Jekyll::Converters::Scss::SyntaxError, error_message)
+      end.to raise_error(Jekyll::Converters::Scss::SyntaxError, error_message)
     end
 
     it "removes byte order mark from compressed Sass" do

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -1,4 +1,6 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe(Jekyll::Converters::Scss) do
   let(:site) do
@@ -27,11 +29,11 @@ SCSS
   end
 
   def compressed(content)
-    content.gsub(/\s+/, '').gsub(/;}/, '}') + "\n"
+    content.gsub(%r!\s+!, "").gsub(%r!;}!, "}") + "\n"
   end
 
   def converter(overrides = {})
-    Jekyll::Converters::Scss.new(site_configuration({"sass" => overrides}))
+    Jekyll::Converters::Scss.new(site_configuration({ "sass" => overrides }))
   end
 
   context "matching file extensions" do
@@ -51,7 +53,6 @@ SCSS
   end
 
   context "when building configurations" do
-
     it "allow caching in unsafe mode" do
       expect(converter.sass_configs[:cache]).to be_truthy
     end
@@ -61,32 +62,32 @@ SCSS
     end
 
     it "allow for other styles" do
-      expect(converter({"style" => :compressed}).sass_configs[:style]).to eql(:compressed)
+      expect(converter({ "style" => :compressed }).sass_configs[:style]).to eql(:compressed)
     end
 
     context "when specifying sass dirs" do
       context "when the sass dir exists" do
         it "allow the user to specify a different sass dir" do
-          FileUtils.mkdir(source_dir('_scss'))
-          expect(converter({"sass_dir" => "_scss"}).sass_configs[:load_paths]).to eql([source_dir("_scss")])
-          FileUtils.rmdir(source_dir('_scss'))
+          FileUtils.mkdir(source_dir("_scss"))
+          expect(converter({ "sass_dir" => "_scss" }).sass_configs[:load_paths]).to eql([source_dir("_scss")])
+          FileUtils.rmdir(source_dir("_scss"))
         end
 
         it "not allow sass_dirs outside of site source" do
           expect(
-            converter({"sass_dir" => "/etc/passwd"}).sass_dir_relative_to_site_source
+            converter({ "sass_dir" => "/etc/passwd" }).sass_dir_relative_to_site_source
           ).to eql(source_dir("etc/passwd"))
         end
       end
     end
 
     context "in safe mode" do
-      let(:verter) {
+      let(:verter) do
         Jekyll::Converters::Scss.new(site.config.merge({
           "sass" => {},
-          "safe" => true
+          "safe" => true,
         }))
-      }
+      end
 
       it "does not allow caching" do
         expect(verter.sass_configs[:cache]).to be_falsey
@@ -118,9 +119,9 @@ SCSS
 
     it "includes the syntax error line in the syntax error message" do
       error_message = 'Invalid CSS after "body ": expected selector or at-rule, was "{" on line 2'
-      expect {
+      expect do
         converter.convert(invalid_content)
-      }.to raise_error(Jekyll::Converters::Scss::SyntaxError, error_message)
+      end.to raise_error(Jekyll::Converters::Scss::SyntaxError, error_message)
     end
 
     it "removes byte order mark from compressed SCSS" do
@@ -150,7 +151,7 @@ SCSS
 
     it "uses a compressed style" do
       instance = scss_converter_instance(site)
-      expect(instance.jekyll_sass_configuration).to eql({"style" => :compressed})
+      expect(instance.jekyll_sass_configuration).to eql({ "style" => :compressed })
       expect(instance.sass_configs[:style]).to eql(:compressed)
     end
   end
@@ -158,15 +159,15 @@ SCSS
   context "importing from external libraries" do
     let(:external_library) { source_dir("bower_components/jquery") }
     let(:verter) { scss_converter_instance(site) }
-    let(:test_css_file) { dest_dir('css', 'main.css') }
+    let(:test_css_file) { dest_dir("css", "main.css") }
 
     context "unsafe mode" do
       let(:site) do
         Jekyll::Site.new(site_configuration.merge({
           "source" => sass_lib,
           "sass"   => {
-            "load_paths" => external_library
-          }
+            "load_paths" => external_library,
+          },
         }))
       end
       before(:each) do
@@ -196,9 +197,9 @@ SCSS
             "sass"   => {
               "load_paths" => [
                 external_library,
-                sass_lib("_sass")
-              ]
-            }
+                sass_lib("_sass"),
+              ],
+            },
           }))
         end
 
@@ -214,8 +215,8 @@ SCSS
           "safe"   => true,
           "source" => sass_lib,
           "sass"   => {
-            "load_paths" => external_library
-          }
+            "load_paths" => external_library,
+          },
         }))
       end
 
@@ -227,7 +228,6 @@ SCSS
         expect(verter.sass_load_paths).to eql([sass_lib("_sass")])
       end
     end
-
   end
 
   context "importing from internal libraries" do
@@ -245,9 +245,9 @@ SCSS
     context "unsafe mode" do
       let(:site) do
         Jekyll::Site.new(site_configuration.merge({
-          "sass"   => {
-            "load_paths" => ["bower_components/*"]
-          }
+          "sass" => {
+            "load_paths" => ["bower_components/*"],
+          },
         }))
       end
 
@@ -259,14 +259,14 @@ SCSS
     context "safe mode" do
       let(:site) do
         Jekyll::Site.new(site_configuration.merge({
-          "safe"   => true,
-          "sass"   => {
+          "safe" => true,
+          "sass" => {
             "load_paths" => [
               "bower_components/*",
               Dir.tmpdir,
-              "../.."
-            ]
-          }
+              "../..",
+            ],
+          },
         }))
       end
 
@@ -281,7 +281,7 @@ SCSS
       it "does not allow traversing outside source directory" do
         converter.sass_load_paths.each do |path|
           expect(path).to include(source_dir)
-          expect(path).not_to include('..')
+          expect(path).not_to include("..")
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,21 +1,22 @@
-# coding: utf-8
-require 'fileutils'
-require 'jekyll'
+# frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+require "fileutils"
+require "jekyll"
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-sass-converter'
+require "jekyll-sass-converter"
 
-if Jekyll::VERSION > "1"
-  Jekyll.logger.log_level = :error
-else
-  Jekyll.logger.log_level = Jekyll::Stevenson::ERROR
-end
+Jekyll.logger.log_level = if Jekyll::VERSION > "1"
+                            :error
+                          else
+                            Jekyll::Stevenson::ERROR
+                          end
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.order = 'random'
+  config.order = "random"
 
   SOURCE_DIR   = File.expand_path("../source", __FILE__)
   DEST_DIR     = File.expand_path("../dest",   __FILE__)
@@ -38,12 +39,12 @@ RSpec.configure do |config|
   def site_configuration(overrides = {})
     Jekyll.configuration(overrides.merge({
       "source"      => source_dir,
-      "destination" => dest_dir
+      "destination" => dest_dir,
     }))
   end
 
   def scss_converter_instance(site)
-    if Jekyll::VERSION >= '3.0'
+    if Jekyll::VERSION >= "3.0"
       site.find_converter_instance(Jekyll::Converters::Scss)
     else
       site.getConverterImpl(Jekyll::Converters::Scss)


### PR DESCRIPTION
This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.