### PR TITLE
Override the cache_location to ensure it's in the site source.

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -103,15 +103,20 @@ module Jekyll
         !safe?
       end
 
+      def cache_location
+        @cache_location ||= Jekyll.sanitized_path(site_source, ".sass-cache")
+      end
+
       def add_charset?
         !!jekyll_sass_configuration["add_charset"]
       end
 
       def sass_configs
         sass_build_configuration_options({
-          "syntax"     => syntax,
-          "cache"      => allow_caching?,
-          "load_paths" => sass_load_paths,
+          "syntax"         => syntax,
+          "cache"          => allow_caching?,
+          "load_paths"     => sass_load_paths,
+          "cache_location" => cache_location,
         })
       end
 

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -57,6 +57,10 @@ SCSS
       expect(converter.sass_configs[:cache]).to be_truthy
     end
 
+    it "sets the cache location" do
+      expect(converter.sass_configs[:cache_location]).to eql(source_dir(".sass-cache"))
+    end
+
     it "set the load paths to the _sass dir relative to site source" do
       expect(converter.sass_configs[:load_paths]).to eql([source_dir("_sass")])
     end


### PR DESCRIPTION
This bug was identified in https://github.com/jekyll/jekyll/pull/6500.

I consider it a bug that we'd write outside the site source at all, so to fix that, specify the cache location for the Sass cache as inside the site source.