### PR TITLE
Configure Sass to load from theme-gem if possible

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -76,6 +76,7 @@ module Jekyll
 
       def sass_load_paths
         paths = user_sass_load_paths + [sass_dir_relative_to_site_source]
+        paths << site.theme.sass_path if site.theme && site.theme.sass_path
 
         if safe?
           # Sanitize paths to prevent any attack vectors (.e.g. `/**/*`)
@@ -124,6 +125,11 @@ module Jekyll
       end
 
       private
+
+      def site
+        @site ||= Jekyll.sites.first
+      end
+
       def site_source
         @site_source ||= File.expand_path(@config["source"]).freeze
       end

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -79,9 +79,10 @@ module Jekyll
         Jekyll.sanitized_path(site_source, sass_dir)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def sass_load_paths
         paths = user_sass_load_paths + [sass_dir_relative_to_site_source]
-        paths << site.theme.sass_path if site.theme && site.theme.sass_path
+        paths << site.theme.sass_path if site.theme&.sass_path
 
         if safe?
           # Sanitize paths to prevent any attack vectors (.e.g. `/**/*`)
@@ -104,6 +105,7 @@ module Jekyll
 
         paths.select { |path| File.directory?(path) }
       end
+      # rubocop:enable Metrics/AbcSize
 
       def allow_caching?
         !safe?

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -132,7 +132,7 @@ module Jekyll
       private
 
       def site
-        @site ||= Jekyll.sites.first
+        @site ||= Jekyll.sites.last
       end
 
       def site_source

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -31,7 +31,9 @@ SASS
   end
 
   def converter(overrides = {})
-    Jekyll::Converters::Sass.new(site_configuration({ "sass" => overrides }))
+    sass_converter_instance(site).dup.tap do |obj|
+      obj.instance_variable_get(:@config)["sass"] = overrides
+    end
   end
 
   context "matching file extensions" do
@@ -46,7 +48,7 @@ SASS
 
   context "converting sass" do
     it "produces CSS" do
-      expect(converter.convert(content)).to eql(compressed(css_output))
+      expect(converter.convert(content)).to eql(css_output)
     end
 
     it "includes the syntax error line in the syntax error message" do

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -34,7 +34,9 @@ SCSS
   end
 
   def converter(overrides = {})
-    Jekyll::Converters::Scss.new(site_configuration({ "sass" => overrides }))
+    scss_converter_instance(site).dup.tap do |obj|
+      obj.instance_variable_get(:@config)["sass"] = overrides
+    end
   end
 
   context "matching file extensions" do
@@ -115,7 +117,7 @@ SCSS
 
   context "converting SCSS" do
     it "produces CSS" do
-      expect(converter.convert(content)).to eql(compressed(css_output))
+      expect(converter.convert(content)).to eql(css_output)
     end
 
     it "includes the syntax error line in the syntax error message" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,10 +40,10 @@ RSpec.configure do |config|
   end
 
   def scss_converter_instance(site)
-    if Jekyll::VERSION >= "3.0"
-      site.find_converter_instance(Jekyll::Converters::Scss)
-    else
-      site.getConverterImpl(Jekyll::Converters::Scss)
-    end
+    site.find_converter_instance(Jekyll::Converters::Scss)
+  end
+
+  def sass_converter_instance(site)
+    site.find_converter_instance(Jekyll::Converters::Sass)
   end
 end


### PR DESCRIPTION
Add `_sass` from within theme-gems to `Sass.load_paths` if the current site uses a theme gem and the theme-gem contains `_sass` directory at its root.