### PR TITLE
Memoize #jekyll_sass_configuration

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -27,11 +27,13 @@ module Jekyll
       end
 
       def jekyll_sass_configuration
-        options = @config["sass"] || {}
-        unless options["style"].nil?
-          options["style"] = options["style"].to_s.gsub(%r!\A:!, "").to_sym
+        @jekyll_sass_configuration ||= begin
+          options = @config["sass"] || {}
+          unless options["style"].nil?
+            options["style"] = options["style"].to_s.gsub(%r!\A:!, "").to_sym
+          end
+          options
         end
-        options
       end
 
       def sass_build_configuration_options(overrides)


### PR DESCRIPTION
`#jekyll_sass_configuration` is called multiple times within an instance:

https://github.com/jekyll/jekyll-sass-converter/blob/0cb7d05e3d408c14a341136a0758bb1efbd1ecd5/lib/jekyll/converters/scss.rb#L48
https://github.com/jekyll/jekyll-sass-converter/blob/0cb7d05e3d408c14a341136a0758bb1efbd1ecd5/lib/jekyll/converters/scss.rb#L60
https://github.com/jekyll/jekyll-sass-converter/blob/0cb7d05e3d408c14a341136a0758bb1efbd1ecd5/lib/jekyll/converters/scss.rb#L62
https://github.com/jekyll/jekyll-sass-converter/blob/0cb7d05e3d408c14a341136a0758bb1efbd1ecd5/lib/jekyll/converters/scss.rb#L66
https://github.com/jekyll/jekyll-sass-converter/blob/0cb7d05e3d408c14a341136a0758bb1efbd1ecd5/lib/jekyll/converters/scss.rb#L71
https://github.com/jekyll/jekyll-sass-converter/blob/0cb7d05e3d408c14a341136a0758bb1efbd1ecd5/lib/jekyll/converters/scss.rb#L108

The method can be safely memoized since the method's primary dependency (`@config`) is initialized once per build session.