### PR TITLE
Cache stateless regexes in class constants

### DIFF
--- a/lib/jekyll/converters/sass.rb
+++ b/lib/jekyll/converters/sass.rb
@@ -7,12 +7,10 @@ require "jekyll/converters/scss"
 module Jekyll
   module Converters
     class Sass < Scss
+      EXTENSION_PATTERN = %r!^\.sass$!i.freeze
+
       safe true
       priority :low
-
-      def matches(ext)
-        ext =~ %r!^\.sass$!i
-      end
 
       def syntax
         :sass

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -7,6 +7,8 @@ module Jekyll
   module Converters
     class Scss < Converter
       BYTE_ORDER_MARK = %r!^\xEF\xBB\xBF!.freeze
+      EXTENSION_PATTERN = %r!^\.scss$!i.freeze
+
       SyntaxError = Class.new(ArgumentError)
 
       safe true
@@ -15,7 +17,7 @@ module Jekyll
       ALLOWED_STYLES = %w(nested expanded compact compressed).freeze
 
       def matches(ext)
-        ext =~ %r!^\.scss$!i
+        ext =~ self.class::EXTENSION_PATTERN
       end
 
       def output_ext(_ext)


### PR DESCRIPTION
A converter's `#matches` is one of the frequently called methods from `Jekyll::Renderer` (for every page / document)
This change eliminates repeated initializations of regexes not dependent on converter instance