### PR TITLE
SyntaxError line and filename are set by SassC

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -119,12 +119,11 @@ module Jekyll
       end
 
       def convert(content)
-        output = ::SassC::Engine.new(content.dup, sass_configs).render
+        output = SassC::Engine.new(content.dup, sass_configs).render
         replacement = add_charset? ? '@charset "UTF-8";' : ""
         output.sub(BYTE_ORDER_MARK, replacement)
-      rescue ::SassC::SyntaxError => e
-        line = e.instance_variable_get(:@line)
-        raise SyntaxError, "#{e} on line #{line}"
+      rescue SassC::SyntaxError => exception
+        raise SyntaxError, exception.to_s
       end
 
       private


### PR DESCRIPTION
SassC includes line number and filename of sass partial in the exception message

Output from older `Sass` with a sample Jekyll site:
```
Invalid CSS after " color": expected ";", was ": #ddd;" on line 15
```
The same output when using this branch:
```
Error: Invalid CSS after " color": expected "}", was ": #ddd;" on line 15 of _sass/_style.scss
from line 8 of stdin >> color: #ddd; --^
```