### PR TITLE
Fix rendering of sourcemap page

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -279,7 +279,7 @@ module Jekyll
       end
 
       def site_source
-        @site_source ||= site.source
+        site.source
       end
     end
   end

--- a/lib/jekyll/source_map_page.rb
+++ b/lib/jekyll/source_map_page.rb
@@ -18,7 +18,7 @@ module Jekyll
     end
 
     def source_map(map)
-      self.output = map
+      self.content = map
     end
 
     def ext


### PR DESCRIPTION
Since `page.content` eventually gets rendered into `page.output`, setting the latter manually has no effect if the former is `nil` or empty.