### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,6 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - vendor/**/*

--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r!^lib/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.3"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency "sassc", "~> 2.0"
 


### PR DESCRIPTION
Since Jekyll 3.x is locked to the 1.x series of this plugin, and because Jekyll 4.0 has dropped support for EOL Ruby 2.3