### PR TITLE
Rectify documentation on sass_dir configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,18 @@ Available options are:
     for details.
 
     Defaults to `compact`.
-
+      
   * **`sass_dir`**
 
-    An array of filesystem-paths which should be searched for Sass partials.
+    A filesystem-path which should be searched for Sass partials.
 
     Defaults to `_sass`
+    
+  * **`load_paths`**
+
+    An array of additional filesystem-paths which should be searched for Sass partials.
+
+    Defaults to `[]`
 
   * **`line_comments`**
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Available options are:
     for details.
 
     Defaults to `compact`.
-      
+
   * **`sass_dir`**
 
     A filesystem-path which should be searched for Sass partials.
 
     Defaults to `_sass`
-    
+
   * **`load_paths`**
 
     An array of additional filesystem-paths which should be searched for Sass partials.


### PR DESCRIPTION
Correct the `sass_dir` description and add `load_paths`

Fixes https://github.com/jekyll/jekyll-sass-converter/issues/107