### PR TITLE
[Theme Inheritance][2/3] Add to SASS load paths from all parent themes

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -152,7 +152,9 @@ module Jekyll
         end
 
         paths.uniq!
-        paths << site.theme.sass_path if site.theme&.sass_path
+        site.theme_list.each do |theme|
+          paths << theme.sass_path if theme&.sass_path
+        end
         paths.select { |path| File.directory?(path) }
       end
       # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
Currently, we add the SASS path from the site's theme as a load path.

However, to correctly support theme inheritance, we need to load sass partials from all parent themes in the theme inheritance chain. We also need to load them in order of hierarchy. The method `Site::theme_list` is currently proposed in jekyll/jekyll#7554. We will need to merge support for the `theme_list` method first before this PR can be merged.