### PR TITLE
Invalid sourcemap generation with highlight content in a SCSS comment

### DIFF
--- a/spec/rouge/_sass/_syntax.scss
+++ b/spec/rouge/_sass/_syntax.scss
@@ -1,0 +1,2 @@
+// {% highlight LANG %}...{% endhighlight %}:
+

--- a/spec/rouge/css/main.scss
+++ b/spec/rouge/css/main.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@import "syntax";

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -374,4 +374,21 @@ describe(Jekyll::Converters::Scss) do
       expect(verter.convert(content)).to eql(css_output)
     end
   end
+
+  context "in a site with rouge syntax inside scss files as comment" do
+    let(:test_css_map_file) { dest_dir("css", "main.css.map") }
+    let(:site) do
+      make_site(
+        "source"      => File.expand_path("rouge", __dir__)
+      )
+    end
+
+    it "generates a valid sourcemap" do
+      site.process
+      expect(File.exist?(test_css_map_file)).to be_truthy
+      expect {
+        JSON.parse(File.read(test_css_map_file))
+      }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Just a breaking testcase, haven't tried to resolve the issue. 

With the following input:

```scss
// {% highlight LANG %}...{% endhighlight %}:
```

It seems like rouge kicks in during sourcemap generation somehow and renders the following instead:

```
{
	"version": 3,
	"file": "main.css",
	"sources": [
		"main.scss",
		"spec/rogue/_sass/_syntax.scss"
	],
	"sourcesContent": [
		"@import \"syntax\";\n",
		"// <figure class="highlight"><pre><code class="language-lang" data-lang="lang">...</code></pre></figure>:\n\n"
	],
	"names": [],
	"mappings": ""
}
```

The quotes are not escaped, and this breaks the sourcemap.

Original breaking scss found here: https://github.com/pmarsceill/just-the-docs/blob/master/_sass/code.scss

Noticed because this breaks sourcemaps on endoflife.date: https://github.com/endoflife-date/endoflife.date/issues/284