### PR TITLE
Update CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Let Jekyll build your Sass and SCSS!
 
-[![Build Status](https://travis-ci.org/jekyll/jekyll-sass-converter.svg?branch=master)](https://travis-ci.org/jekyll/jekyll-sass-converter)
-[![Windows Build status](https://img.shields.io/appveyor/ci/jekyll/jekyll-sass-converter/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/jekyll/jekyll-sass-converter/branch/master)
+[![Continuous Integration](https://github.com/jekyll/jekyll-sass-converter/actions/workflows/ci.yml/badge.svg)](https://github.com/jekyll/jekyll-sass-converter/actions/workflows/ci.yml)
 
 
 ## Installation


### PR DESCRIPTION
This PR removes old Travis/Appveyor badges and adds GitHub Actions badge.