### PR TITLE
Use new sass-embedded api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 4.0"
 gem "minima"
 
-gem "sass-embedded", "~> 0.9.1" if RUBY_VERSION >= "2.6.0"
+gem "sass-embedded", "~> 0.19.0" if RUBY_VERSION >= "2.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 4.0"
 gem "minima"
 
-gem "sass-embedded", "~> 0.19.0" if RUBY_VERSION >= "2.6.0"
+gem "sass-embedded", "~> 1.0" if RUBY_VERSION >= "2.6.0"

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -207,7 +207,7 @@ module Jekyll
           :source_map_include_sources => true,
           :style                      => sass_style,
           :syntax                     => syntax == :sass ? :indented : syntax,
-          :url                        => url,
+          :url                        => sass_file_url,
         }
       end
 
@@ -241,10 +241,10 @@ module Jekyll
       end
 
       # The URL of the input scss (or sass) file. This information will be used for error reporting.
-      def url
+      def sass_file_url
         return if associate_page_failed?
 
-        file_path_to_uri(File.join(site_source, sass_page.relative_path))
+        file_url_from_path(File.join(site_source, sass_page.relative_path))
       end
 
       # The value of the `line_comments` option.
@@ -341,10 +341,10 @@ module Jekyll
       end
 
       def site_source_url
-        @site_source_url ||= file_path_to_uri("#{site_source}/")
+        @site_source_url ||= file_url_from_path("#{site_source}/")
       end
 
-      def file_path_to_uri(path)
+      def file_url_from_path(path)
         Addressable::URI.encode("file://#{path.start_with?("/") ? "" : "/"}#{path}")
       end
     end


### PR DESCRIPTION
`sass-embedded` gem recently implemented a [new ruby API](https://www.rubydoc.info/gems/sass-embedded/0.15.0/Sass/Embedded#compile_string-instance_method) that mirrors the behavior of [new sass JS API](https://github.com/sass/dart-sass/blob/main/CHANGELOG.md#1450). The old API is deprecated.

This PR updates jekyll-sass-converter to use the new API.