### PR TITLE
Update `sass-embedded` info in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,21 @@ and communicates with the dart-sass compiler by sending / receiving
 input-output channel.
 
 To use the `sass-embedded` implementation, you need to first install the `sass-embedded` gem
-either via your `Gemfile` and Bundler, or directly. Then, you have to specify `sass-embedded`
-as the desired implementation in your `_config.yml`:
+either via your `Gemfile` and Bundler, or directly.
+
+Add this line to your application's Gemfile:
+
+    gem 'sass-embedded', '~> 1.0'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install sass-embedded
+
+Then, you have to specify `sass-embedded` as the desired implementation in your `_config.yml`:
 
 ```yaml
 sass:

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ and communicates with the dart-sass compiler by sending / receiving
 [protobuf](https://github.com/protocolbuffers/protobuf) messages via the standard
 input-output channel.
 
-*`sass-embedded` is currently experimental, unstable and requires Ruby 2.6 or higher.*
-
 To use the `sass-embedded` implementation, you need to first install the `sass-embedded` gem
 either via your `Gemfile` and Bundler, or directly. Then, you have to specify `sass-embedded`
 as the desired implementation in your `_config.yml`:


### PR DESCRIPTION
`sass-embedded` just had [first stable release 1.0.0](https://rubygems.org/gems/sass-embedded/versions/1.0.0). Removing the note about it being experimental.