### PR TITLE
Drop support for sassc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         - "ubuntu-latest"
         - "windows-latest"
         ruby_version:
-        - "2.5"
+        - "2.6"
         - "2.7"
         - "3.0"
     steps:
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-        - 2.5
+        - 2.6
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
   Exclude:
     - vendor/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 4.0"
 gem "minima"
-
-gem "sass-embedded", "~> 1.0" if RUBY_VERSION >= "2.6.0"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ page](https://jekyllrb.com/docs/assets/).
 
 ### Sass Implementations
 
-#### SassC
+Starting with `v3.0`, Jekyll Sass Converter uses `sass-embedded` for Sass implmentation.
 
-By default, Jekyll Sass Converter uses [sassc](https://rubygems.org/gems/sassc)
-for Sass implmentation. `sassc` is based on LibSass, and
-[LibSass is deprecated](https://sass-lang.com/blog/libsass-is-deprecated).
+Please see [migrate from 2.x to 3.x](#migrate-from-2x-to-3x) for more information.
 
 #### Sass Embedded
 
@@ -45,28 +43,6 @@ The host runs [Dart Sass compiler](https://github.com/sass/dart-sass-embedded) a
 and communicates with the dart-sass compiler by sending / receiving
 [protobuf](https://github.com/protocolbuffers/protobuf) messages via the standard
 input-output channel.
-
-To use the `sass-embedded` implementation, you need to first install the `sass-embedded` gem
-either via your `Gemfile` and Bundler, or directly.
-
-Add this line to your application's Gemfile:
-
-    gem 'sass-embedded', '~> 1.0'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install sass-embedded
-
-Then, you have to specify `sass-embedded` as the desired implementation in your `_config.yml`:
-
-```yaml
-sass:
-  implementation: sass-embedded
-```
 
 ### Source Maps
 
@@ -92,22 +68,14 @@ Configuration options are specified in the `_config.yml` file in the following w
 
 Available options are:
 
-  * **`implementation`**
-
-    Sets the Sass implementation to use.
-    Can be `sassc` or `sass-embedded`.
-
-    Defaults to `sassc`.
-
   * **`style`**
 
     Sets the style of the CSS-output.
-    Can be `nested`, `compact`, `compressed`, or `expanded`.
+    Can be `compressed` or `expanded`.
     See the [SASS_REFERENCE](https://sass-lang.com/documentation/cli/dart-sass#style)
     for details.
 
-    Defaults to `compact` for `sassc`.
-    Defaults to `expanded` for `sass-embedded`.
+    Defaults to `expanded`.
 
   * **`sass_dir`**
 
@@ -121,14 +89,6 @@ Available options are:
 
     Defaults to `[]`
 
-  * **`line_comments`**
-
-    When set to _true_, the line number and filename of the source is included in the compiled
-    CSS-file. Useful for debugging when the _source map_ is not available, but might
-    considerably increase the size of the generated CSS files.
-
-    Defaults to `false`.
-
   * **`sourcemap`**
 
     Controls when source maps shall be generated.
@@ -141,6 +101,55 @@ Available options are:
 
     Defaults to `always`.
 
+## Migrate from 2.x to 3.x
+
+Classic GitHub Pages experience still uses [1.x version of jekyll-sass-converter](https://pages.github.com/versions/).
+
+To use latest Jekyll and Jekyll Sass Converter on GitHub Pages,
+[you can now deploy to a GitHub Pages site using GitHub Actions](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/).
+
+### Dropped `implmentation` Option
+
+In `v3.0.0`, `sass-embedded` gem becomes the default Sass implmentation, and `sassc` gem
+is no longer supported. As part of this change, support for Ruby 2.5 is dropped.
+
+### Dropped `add_charset` Option
+
+The Converter will no longer emit `@charset "UTF-8";` or a U+FEFF (byte-order marker) for
+`sassify` and `scssify` Jekyll filters so that this option is no longer needed.
+
+### Dropped `line_comments` Option
+
+`sass-embedded` does not support `line_comments` option.
+
+### Dropped support of importing files with non-standard extension names
+
+`sass-embedded` only allows importing files that have extension names of `.sass`, `.scss`
+or `.css`. Scss syntax in files with `.css` extension name will result in a syntax error.
+
+### Dropped support of importing files relative to site source
+
+In `v2.x`, the Converter allowed imports using paths relative to site source directory,
+even if the site source directory is not in Sass `load_paths`. This is a side effect of a
+bug in the Converter, which will remain as is in `v2.x` due to its usage in the wild.
+
+In `v3.x`, imports using paths relative to site source directory will not work out of box.
+To allow these imports, `.` (meaning current directory, or site source directory) need to
+be explicitly added to `load_paths` option.
+
+### Dropped support of importing files with the same filename as their parent file
+
+In `v2.x`, the Converter allowed imports of files with the same filename as their parent
+file from `sass_dir` or `load_paths`. This is a side effect of a bug in the Converter,
+which will remain as is in `v2.x` due to its usage in the wild.
+
+In `v3.x`, imports using the same filename of parent file will create a circular import.
+To fix these imports, rename either of the files, or use complete relative path from the
+parent file.
+
+### Behavioral Differences in Sass Implementation
+
+Please see https://github.com/sass/dart-sass#behavioral-differences-from-ruby-sass.
 
 ## Contributing
 

--- a/jekyll-sass-converter.gemspec
+++ b/jekyll-sass-converter.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r!^lib/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_runtime_dependency "sassc", "> 2.0.1", "< 3.0"
+  spec.add_runtime_dependency "sass-embedded", "~> 1.54"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/jekyll/converters/sass.rb
+++ b/lib/jekyll/converters/sass.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "sassc"
-require "jekyll/utils"
 require "jekyll/converters/scss"
 
 module Jekyll
@@ -13,7 +11,7 @@ module Jekyll
       priority :low
 
       def syntax
-        :sass
+        :indented
       end
     end
   end

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
-require "sassc"
+# stdlib
+require "json"
+
+# 3rd party
+require "addressable/uri"
+require "sass-embedded"
+
+# jekyll
 require "jekyll/utils"
 require "jekyll/source_map_page"
 
 module Jekyll
   module Converters
     class Scss < Converter
-      BYTE_ORDER_MARK = %r!^\xEF\xBB\xBF!.freeze
       EXTENSION_PATTERN = %r!^\.scss$!i.freeze
 
       SyntaxError = Class.new(ArgumentError)
@@ -35,8 +41,7 @@ module Jekyll
         end
       end
 
-      ALLOWED_IMPLEMENTATIONS = %w(sassc sass-embedded).freeze
-      ALLOWED_STYLES = %w(nested expanded compact compressed).freeze
+      ALLOWED_STYLES = %w(expanded compressed).freeze
 
       # Associate this Converter with the "page" object that manages input and output files for
       # this converter.
@@ -91,14 +96,6 @@ module Jekyll
         end
       end
 
-      def sass_build_configuration_options(overrides)
-        return overrides if safe?
-
-        Jekyll::Utils.symbolize_hash_keys(
-          Jekyll::Utils.deep_merge_hashes(jekyll_sass_configuration, overrides)
-        )
-      end
-
       def syntax
         :scss
       end
@@ -109,17 +106,9 @@ module Jekyll
         jekyll_sass_configuration["sass_dir"]
       end
 
-      def sass_implementation
-        implementation = jekyll_sass_configuration["implementation"]
-        ALLOWED_IMPLEMENTATIONS.include?(implementation) ? implementation : "sassc"
-      end
-
       def sass_style
-        # `:expanded` is the default output style for newer sass implementations.
-        # For backward compatibility, `:compact` is kept as the default output style for sassc.
-        default = sass_implementation == "sassc" ? :compact : :expanded
-        style = jekyll_sass_configuration.fetch("style", default)
-        ALLOWED_STYLES.include?(style.to_s) ? style.to_sym : default
+        style = jekyll_sass_configuration["style"]
+        ALLOWED_STYLES.include?(style.to_s) ? style.to_sym : :expanded
       end
 
       def user_sass_load_paths
@@ -127,9 +116,8 @@ module Jekyll
       end
 
       def sass_dir_relative_to_site_source
-        @sass_dir_relative_to_site_source ||= begin
+        @sass_dir_relative_to_site_source ||=
           Jekyll.sanitized_path(site_source, sass_dir).sub(site.source + "/", "")
-        end
       end
 
       # rubocop:disable Metrics/AbcSize
@@ -155,73 +143,34 @@ module Jekyll
       end
       # rubocop:enable Metrics/AbcSize
 
-      def allow_caching?
-        !safe?
-      end
-
-      def add_charset?
-        !!jekyll_sass_configuration["add_charset"]
-      end
-
       def sass_configs
-        sass_build_configuration_options(
-          :style                => sass_style,
-          :syntax               => syntax,
-          :filename             => filename,
-          :output_path          => output_path,
-          :source_map_file      => source_map_file,
-          :load_paths           => sass_load_paths,
-          :omit_source_map_url  => !sourcemap_required?,
-          :source_map_contents  => true,
-          :line_comments_option => line_comments_option
-        )
-      end
-
-      def convert(content)
-        case sass_implementation
-        when "sass-embedded"
-          Jekyll::External.require_with_graceful_fail("sass-embedded")
-          sass_embedded_convert(content)
-        when "sassc"
-          sass_convert(content)
-        end
-      end
-
-      private
-
-      def sass_convert(content)
-        config = sass_configs
-        engine = SassC::Engine.new(content.dup, config)
-        output = engine.render
-        sass_generate_source_map(engine) if sourcemap_required?
-        replacement = add_charset? ? '@charset "UTF-8";' : ""
-        output.sub(BYTE_ORDER_MARK, replacement)
-      rescue SassC::SyntaxError => e
-        raise SyntaxError, e.to_s
-      end
-
-      def sass_embedded_config
         {
           :load_paths                 => sass_load_paths,
+          :charset                    => !associate_page_failed?,
           :source_map                 => sourcemap_required?,
           :source_map_include_sources => true,
           :style                      => sass_style,
-          :syntax                     => syntax == :sass ? :indented : syntax,
+          :syntax                     => syntax,
           :url                        => sass_file_url,
         }
       end
 
-      def sass_embedded_convert(content)
-        output = ::Sass.compile_string(content, **sass_embedded_config)
-        sass_embedded_generate_source_map(output.source_map) if sourcemap_required?
-        replacement = add_charset? ? '@charset "UTF-8";' : ""
-        source_mapping_url = Addressable::URI.encode(File.basename(source_map_file))
-        eof = sourcemap_required? ? "\n\n/*# sourceMappingURL=#{source_mapping_url} */" : "\n"
-        output.css.sub(BYTE_ORDER_MARK, replacement) + eof
+      def convert(content)
+        output = ::Sass.compile_string(content, **sass_configs)
+
+        if sourcemap_required?
+          source_map = process_source_map(output.source_map)
+          generate_source_map_page(source_map)
+          "#{output.css}\n\n/*# sourceMappingURL=#{source_mapping_url(source_map)} */"
+        else
+          "#{output.css}\n"
+        end
       rescue ::Sass::CompileError => e
         Jekyll.logger.error e.full_message
         raise SyntaxError, e.message
       end
+
+      private
 
       # The Page instance for which this object acts as a converter.
       attr_reader :sass_page
@@ -230,30 +179,11 @@ module Jekyll
         !sass_page
       end
 
-      # The name of the input scss (or sass) file. This information will be used for error
-      # reporting and will written into the source map file as main source.
-      #
-      # Returns the name of the input file or "stdin" if #associate_page failed
-      def filename
-        return "stdin" if associate_page_failed?
-
-        File.join(site_source_relative_from_pwd, sass_page.name)
-      end
-
       # The URL of the input scss (or sass) file. This information will be used for error reporting.
       def sass_file_url
         return if associate_page_failed?
 
         file_url_from_path(File.join(site_source, sass_page.relative_path))
-      end
-
-      # The value of the `line_comments` option.
-      # When set to `true` causes the line number and filename of the source be emitted into the
-      # compiled CSS-file. Useful for debugging when the source-map is not available.
-      #
-      # Returns the value of the `line_comments`-option chosen by the user or 'false' by default.
-      def line_comments_option
-        jekyll_sass_configuration.fetch("line_comments", false)
       end
 
       # The value of the `sourcemap` option chosen by the user.
@@ -275,56 +205,49 @@ module Jekyll
         !(sourcemap_option == :development && Jekyll.env != "development")
       end
 
-      # The name of the generated css file. This information will be written into the source map
-      # file as a backward reference to the input.
-      #
-      # Returns the name of the css file or "stdin.css" if #associate_page failed
-      def output_path
-        return "stdin.css" if associate_page_failed?
-
-        File.join(site_source_relative_from_pwd, sass_page.basename + ".css")
-      end
-
-      # The name of the generated source map file. This information will be written into the
-      # css file to reference to the source map.
-      #
-      # Returns the name of the css file or "" if #associate_page failed
-      def source_map_file
-        return "" if associate_page_failed?
-
-        File.join(site_source_relative_from_pwd, sass_page.basename + ".css.map")
-      end
-
       def source_map_page
         return if associate_page_failed?
 
         @source_map_page ||= SourceMapPage.new(sass_page)
       end
 
-      # Reads the source-map from the engine and adds it to the source-map-page.
-      #
-      # @param [::SassC::Engine] engine The sass Compiler engine.
-      def sass_generate_source_map(engine)
-        return if associate_page_failed?
-
-        source_map_page.source_map(engine.source_map)
-        site.pages << source_map_page
-      rescue ::SassC::NotRenderedError => e
-        Jekyll.logger.warn "Could not generate source map #{e.message} => #{e.cause}"
+      # Returns the directory that source map sources are relative to.
+      def sass_source_root
+        if associate_page_failed?
+          site_source
+        else
+          File.join(site_source, File.dirname(sass_page.relative_path))
+        end
       end
 
-      # Reads the source-map and adds it to the source-map-page.
-      def sass_embedded_generate_source_map(source_map)
+      # Converts file urls in source map to relative paths.
+      #
+      # Returns processed source map string.
+      def process_source_map(source_map)
+        map_data = JSON.parse(source_map)
+        unless associate_page_failed?
+          map_data["file"] = Addressable::URI.encode(sass_page.basename + ".css")
+        end
+        source_root_url = Addressable::URI.parse(file_url_from_path("#{sass_source_root}/"))
+        map_data["sources"].map! do |s|
+          s.start_with?("file:") ? Addressable::URI.parse(s).route_from(source_root_url).to_s : s
+        end
+        JSON.generate(map_data)
+      end
+
+      # Adds the source-map to the source-map-page and adds it to `site.pages`.
+      def generate_source_map_page(source_map)
         return if associate_page_failed?
 
-        map_data = JSON.parse(source_map)
-        map_data["file"] = Addressable::URI.encode(File.basename(output_path))
-        map_data["sources"].map! do |s|
-          s.start_with?("file:") ? Addressable::URI.parse(s).route_from(site_source_url) : s
-        end
-
-        source_map_page.source_map(JSON.generate(map_data))
+        source_map_page.source_map(source_map)
         site.pages << source_map_page
+      end
+
+      # Returns a source mapping url for given source-map.
+      def source_mapping_url(_source_map)
+        return if associate_page_failed?
+
+        Addressable::URI.encode(sass_page.basename + ".css.map")
       end
 
       def site
@@ -333,15 +256,6 @@ module Jekyll
 
       def site_source
         site.source
-      end
-
-      def site_source_relative_from_pwd
-        @site_source_relative_from_pwd ||=
-          Pathname.new(site_source).relative_path_from(Pathname.new(Dir.pwd)).to_s
-      end
-
-      def site_source_url
-        @site_source_url ||= file_url_from_path("#{site_source}/")
       end
 
       def file_url_from_path(path)

--- a/script/test
+++ b/script/test
@@ -2,10 +2,5 @@
 
 set -e
 
-echo "Running rspec with sassc"
-SASS_IMPLEMENTATION=sassc bundle exec rspec $@
-
-if bundle info sass-embedded; then
-  echo "Running rspec with sass-embedded"
-  SASS_IMPLEMENTATION=sass-embedded bundle exec rspec $@
-fi
+echo "Running rspec with sass-embedded"
+bundle exec rspec $@

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,25 +10,10 @@ require "jekyll-sass-converter"
 
 Jekyll.logger.log_level = :error
 
-module GlobalSharedContext
-  extend RSpec::SharedContext
-
-  let(:sass_implementation) { ENV["SASS_IMPLEMENTATION"] }
-  let(:sass_embedded?) { sass_implementation == "sass-embedded" }
-end
-
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = "random"
-
-  config.include GlobalSharedContext
-  config.before(:example) do
-    if sass_implementation
-      allow_any_instance_of(Jekyll::Converters::Scss)
-        .to(receive(:sass_implementation).and_return(sass_implementation))
-    end
-  end
 
   SOURCE_DIR   = File.expand_path("source", __dir__)
   DEST_DIR     = File.expand_path("dest",   __dir__)


### PR DESCRIPTION
> My proposal would be to produce a new MAJOR version of jekyll-sass-converter that:
> 
> 1. Defaults to the sass-embedded implementation
> 2. Changes this import behavior
> 3. Removes the sassc compatibility entirely
> 4. Documents the upgrade path

Per above comment and discussion in #137, this PR drops support for sassc.

### Changes

- Remove sassc.
- Bump `required_ruby_version` to `>= 2.6.0` as it is a requirement for `sass-embedded`.
- Drop the undocumented `add_charset` option. Whether to add `@charset` or not will now be automatically determined based on `associate_page_failed?`. If a page is associated, sass will automatically add `@charset` or BOM if output contains any non-ASCII character. Otherwise, e.g. when called via `sassify`/`scssify` filters, `@charset` or BOM will be omitted.
- Generate embedded base64 source map for `sassify`/`scssify` filters if source map is enabled.
- Cherry-pick source map relative path change from #137.