### PR TITLE
Support inline sourcemap for sassify/scssify filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ The Converter will no longer emit `@charset "UTF-8";` or a U+FEFF (byte-order ma
 
 ### Dropped `line_comments` Option
 
-`sass-embedded` does not support `line_comments` option.
+`sass-embedded` does not support `line_comments` option. However, the Converter now has
+improved support for source map so that `line_comments` is no longer necessary. For
+inline css generated via `sassify` and `scssify` Jekyll filters, a base64-encoded source
+map is inlined when source map is enabled.
 
 ### Dropped support of importing files with non-standard extension names
 

--- a/spec/nested_source/src/scssify.html
+++ b/spec/nested_source/src/scssify.html
@@ -1,0 +1,5 @@
+---
+scss: |
+  @import "grid";
+---
+<style>{{ page.scss | scssify }}</style>

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -54,7 +54,8 @@ describe(Jekyll::Converters::Sass) do
 
   context "converting sass" do
     it "produces CSS" do
-      expect(converter.convert(content)).to eql(expanded_css_output)
+      overrides = { "sourcemap" => :never }
+      expect(converter(overrides).convert(content)).to eql(expanded_css_output)
     end
 
     it "includes the syntax error line in the syntax error message" do
@@ -65,13 +66,13 @@ describe(Jekyll::Converters::Sass) do
     end
 
     it "does not include the charset without an associated page" do
-      overrides = { "style" => :expanded }
+      overrides = { "sourcemap" => :never, "style" => :expanded }
       result = converter(overrides).convert(%(a\n  content: "あ"))
       expect(result).to eql(%(a {\n  content: "あ";\n}\n))
     end
 
     it "does not include the BOM without an associated page" do
-      overrides = { "style" => :compressed }
+      overrides = { "sourcemap" => :never, "style" => :compressed }
       result = converter(overrides).convert(%(a\n  content: "あ"))
       expect(result).to eql(%(a{content:"あ"}\n))
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
@@ -83,7 +84,8 @@ describe(Jekyll::Converters::Sass) do
       make_site(
         "source"      => File.expand_path("pages-collection", __dir__),
         "sass"        => {
-          "style" => :expanded,
+          "sourcemap" => :never,
+          "style"     => :expanded,
         },
         "collections" => {
           "pages" => {
@@ -104,7 +106,8 @@ describe(Jekyll::Converters::Sass) do
       make_site(
         "source" => File.expand_path("[alpha]beta", __dir__),
         "sass"   => {
-          "style" => :expanded,
+          "sourcemap" => :never,
+          "style"     => :expanded,
         }
       )
     end

--- a/spec/source/sassify.html
+++ b/spec/source/sassify.html
@@ -1,0 +1,6 @@
+---
+sass: |
+  a
+    b: c
+---
+<style>{{ page.sass | sassify }}</style>

--- a/spec/source/scssify.html
+++ b/spec/source/scssify.html
@@ -1,0 +1,7 @@
+---
+scss: |
+  a {
+    b: c;
+  }
+---
+<style>{{ page.scss | scssify }}</style>


### PR DESCRIPTION
This PR adds support for inline base64 source map when converter is called without associated page e.g. from liquid filters.