### PR TITLE
Remove extra newline in css output

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -165,7 +165,7 @@ module Jekyll
           generate_source_map_page(source_map)
 
           if (sm_url = source_mapping_url)
-            result += "\n/*# sourceMappingURL=#{sm_url} */"
+            result += "#{sass_style == :compressed ? "" : "\n\n"}/*# sourceMappingURL=#{sm_url} */"
           end
         end
 

--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -158,14 +158,14 @@ module Jekyll
 
       def convert(content)
         output = ::Sass.compile_string(content, **sass_configs)
-        result = +"#{output.css}\n"
+        result = output.css
 
         if sourcemap_required?
           source_map = process_source_map(output.source_map)
           generate_source_map_page(source_map)
 
           if (sm_url = source_mapping_url)
-            result << "\n/*# sourceMappingURL=#{sm_url} */"
+            result += "\n/*# sourceMappingURL=#{sm_url} */"
           end
         end
 

--- a/spec/sass_converter_spec.rb
+++ b/spec/sass_converter_spec.rb
@@ -22,7 +22,7 @@ describe(Jekyll::Converters::Sass) do
   end
 
   let(:expanded_css_output) do
-    <<~CSS
+    <<~CSS.chomp
       body {
         font-family: Helvetica, sans-serif;
         font-color: fuschia;
@@ -67,13 +67,13 @@ describe(Jekyll::Converters::Sass) do
     it "does not include the charset without an associated page" do
       overrides = { "style" => :expanded }
       result = converter(overrides).convert(%(a\n  content: "あ"))
-      expect(result).to eql(%(a {\n  content: "あ";\n}\n))
+      expect(result).to eql(%(a {\n  content: "あ";\n}))
     end
 
     it "does not include the BOM without an associated page" do
       overrides = { "style" => :compressed }
       result = converter(overrides).convert(%(a\n  content: "あ"))
-      expect(result).to eql(%(a{content:"あ"}\n))
+      expect(result).to eql(%(a{content:"あ"}))
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
   end

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -156,7 +156,7 @@ describe(Jekyll::Converters::Scss) do
 
     it "imports SCSS partial" do
       expect(File.read(test_css_file)).to eql(
-        ".half{width:50%}\n/*# sourceMappingURL=main.css.map */"
+        ".half{width:50%}/*# sourceMappingURL=main.css.map */"
       )
     end
 
@@ -195,7 +195,7 @@ describe(Jekyll::Converters::Scss) do
       it "brings in the grid partial" do
         site.process
 
-        expected = "a {\n  color: #999999;\n}\n/*# sourceMappingURL=main.css.map */"
+        expected = "a {\n  color: #999999;\n}\n\n/*# sourceMappingURL=main.css.map */"
         expect(File.read(test_css_file)).to eql(expected)
       end
 

--- a/spec/scss_converter_spec.rb
+++ b/spec/scss_converter_spec.rb
@@ -23,7 +23,7 @@ describe(Jekyll::Converters::Scss) do
   end
 
   let(:expanded_css_output) do
-    <<~CSS
+    <<~CSS.chomp
       body {
         font-family: Helvetica, sans-serif;
         font-color: fuschia;
@@ -135,13 +135,13 @@ describe(Jekyll::Converters::Scss) do
     it "does not include the charset without an associated page" do
       overrides = { "style" => :expanded }
       result = converter(overrides).convert(%(a{content:"あ"}))
-      expect(result).to eql(%(a {\n  content: "あ";\n}\n))
+      expect(result).to eql(%(a {\n  content: "あ";\n}))
     end
 
     it "does not include the BOM without an associated page" do
       overrides = { "style" => :compressed }
       result = converter(overrides).convert(%(a{content:"あ"}))
-      expect(result).to eql(%(a{content:"あ"}\n))
+      expect(result).to eql(%(a{content:"あ"}))
       expect(result.bytes.to_a[0..2]).not_to eql([0xEF, 0xBB, 0xBF])
     end
   end
@@ -156,7 +156,7 @@ describe(Jekyll::Converters::Scss) do
 
     it "imports SCSS partial" do
       expect(File.read(test_css_file)).to eql(
-        ".half{width:50%}\n\n/*# sourceMappingURL=main.css.map */"
+        ".half{width:50%}\n/*# sourceMappingURL=main.css.map */"
       )
     end
 
@@ -195,7 +195,7 @@ describe(Jekyll::Converters::Scss) do
       it "brings in the grid partial" do
         site.process
 
-        expected = "a {\n  color: #999999;\n}\n\n/*# sourceMappingURL=main.css.map */"
+        expected = "a {\n  color: #999999;\n}\n/*# sourceMappingURL=main.css.map */"
         expect(File.read(test_css_file)).to eql(expected)
       end
 


### PR DESCRIPTION
This PR removes an extra new line in the css output to make it fully consistent with dart-sass. Previously, a newline is explicitly added to make output compatible with sassc so that the same test case would pass for both implementations. Now the support for sassc is dropped, there is no need to keep that extra newline.

Although this is more of a cosmetic thing, it also has a small performance benefit of avoid copying the frozen string returned from protobuf when source map is disabled.