### PR TITLE
Update sass embedded protocol documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please see [migrate from 2.x to 3.x](#migrate-from-2x-to-3x) for more informatio
 #### Sass Embedded
 
 [sass-embedded](https://rubygems.org/gems/sass-embedded) is a host for the
-[Sass embedded protocol](https://github.com/sass/embedded-protocol).
+[Sass embedded protocol](https://github.com/sass/sass/blob/HEAD/spec/embedded-protocol.md).
 
 The host runs [Dart Sass compiler](https://github.com/sass/dart-sass#embedded-dart-sass) as a subprocess
 and communicates with the dart-sass compiler by sending / receiving


### PR DESCRIPTION
This PR updates the outdated link for sass embedded protocol in documentation.