### PR TITLE
Display sass error in browser with livereload

### DIFF
--- a/lib/jekyll/converters/scss.rb
+++ b/lib/jekyll/converters/scss.rb
@@ -172,7 +172,11 @@ module Jekyll
         result
       rescue ::Sass::CompileError => e
         Jekyll.logger.error e.full_message
-        raise SyntaxError, e.message
+        if livereload? && e.respond_to?(:to_css)
+          e.to_css
+        else
+          raise SyntaxError, e.message
+        end
       end
 
       private
@@ -182,6 +186,11 @@ module Jekyll
 
       def associate_page_failed?
         !sass_page
+      end
+
+      # Returns `true` if jekyll is serving with livereload.
+      def livereload?
+        !!@config["serving"] && !!@config["livereload"]
       end
 
       # The URL of the input scss (or sass) file. This information will be used for error reporting.


### PR DESCRIPTION
This PR adds a new feature for live-reload where css compilation error will be displayed on the browser. Please see the demo video below on how it works for users.

This feature depends on `sass-embedded >=1.69.6`. In order to simplify the user experience, this PR does not bump up the required dependency version, but rather works based on feature detection. This feature is enabled automatically if sass-embedded supports it.

Demo:

https://github.com/jekyll/jekyll-sass-converter/assets/899645/5903f311-5aad-40a6-9351-76d3cd49a7f9