### PR TITLE
Bump `actions/checkout` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         - "2.7"
         - "3.0"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
@@ -43,7 +43,7 @@ jobs:
         ruby_version:
         - 2.6
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
       - name: "Set up Ruby ${{ matrix.ruby_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         ruby_version: ["2.7"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Bump `actions/checkout` to v4 in our workflows.